### PR TITLE
in _encode function, add cast to unicode string to allow encoding=asc…

### DIFF
--- a/src/SerialLibrary/__init__.py
+++ b/src/SerialLibrary/__init__.py
@@ -173,7 +173,11 @@ class SerialLibrary:
 
         If encoding is not specified, instance's default encoding will be used.
         """
+        if not isinstance(ustring, unicode_):
+            ustring = unic(ustring)
+            
         return ustring.encode(encoding or self._encoding, encoding_mode)
+
 
     def _decode(self, bstring, encoding=None, encoding_mode='replace'):
         """


### PR DESCRIPTION
…ii to work properly

In python 3.x (tested with 3.7) using the "Write Data" keyword with the library initialized with "encoding=ascii" will trow an error since the string is not passed as unicode.
To fix this in the _encode function I added check for unicode string or else cast the string to unicode.