### PR TITLE
Update setup.py for python3.7+ support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from imp import load_source
 from os.path import abspath, dirname, join
 from sys import platform
 
@@ -18,9 +17,11 @@ if platform.startswith('java'):
 
 
 CURDIR = dirname(abspath(__file__))
-VERSION = load_source(
-    'version', 'version',
-    open(join(CURDIR, 'src', 'SerialLibrary', 'version.py'))).VERSION
+
+with open(join(CURDIR, 'src', 'SerialLibrary', 'version.py')) as f:
+    exec(f.read())
+    VERSION = get_version()
+
 README = open(join(CURDIR, 'README.rst')).read()
 CLASSIFIERS = '\n'.join(
     map(' :: '.join, [

--- a/src/SerialLibrary/version.py
+++ b/src/SerialLibrary/version.py
@@ -1,1 +1,4 @@
 VERSION = (0, 3, 1)
+
+def get_version():
+    return VERSION;


### PR DESCRIPTION
The current setup.py shows the following error with python 3.7 because `imp.load_source` is deprecated there. 

For instance, in my environment, 
```
# python3 --version
Python 3.7.3
# python3 setup.py install
setup.py:3: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  from imp import load_source
Traceback (most recent call last):
  File "setup.py", line 23, in <module>
    open(join(CURDIR, 'src', 'SerialLibrary', 'version.py'))).VERSION
  File "/usr/lib64/python3.7/imp.py", line 171, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 724, in exec_module
  File "<frozen importlib._bootstrap_external>", line 859, in get_code
  File "/usr/lib64/python3.7/imp.py", line 152, in get_data
    self.file = file = open(self.path, 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'version'
```

This PR solves the problem [as robotframework does](https://github.com/robotframework/robotframework/blob/master/setup.py#L11).
