### PR TITLE
Fix wrong encoding in case of byte streams.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,16 @@
 Release Notes
 =============
 
+0.3.2
+-------
+
+Fix wrong encoding in case of byte streams.
+Fix wrong parameter name of pyserial method call.
+
 0.3.1
 -------
 
-Added Python 3.5+ supprt.
+Added Python 3.5+ support.
 
 0.2.4
 -------

--- a/src/SerialLibrary/__init__.py
+++ b/src/SerialLibrary/__init__.py
@@ -173,7 +173,10 @@ class SerialLibrary:
 
         If encoding is not specified, instance's default encoding will be used.
         """
-        return ustring.encode(encoding or self._encoding, encoding_mode)
+        if isinstance(ustring, bytes):
+            return ustring
+        else:
+            return ustring.encode(encoding or self._encoding, encoding_mode)
 
     def _decode(self, bstring, encoding=None, encoding_mode='replace'):
         """
@@ -527,7 +530,7 @@ class SerialLibrary:
         if terminator != LF:
             terminator = self._encode(terminator)
         return self._decode(
-            self._port(port_locator).read_until(terminator=terminator, size=size),
+            self._port(port_locator).read_until(expected=terminator, size=size),
             encoding)
 
     def port_should_have_unread_bytes(self, port_locator=None):

--- a/src/SerialLibrary/version.py
+++ b/src/SerialLibrary/version.py
@@ -1,1 +1,4 @@
-VERSION = (0, 3, 1)
+VERSION = (0, 3, 2)
+
+def get_version():
+    return VERSION;


### PR DESCRIPTION
Fix wrong parameter name of pyserial method call.