### PR TITLE
pyproject.toml: Replace install_requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,5 @@ packages = [
   ]
 
 [tool.poetry.dependencies]
-install_requires=["robotframework", "pyserial"]
-
-
-
+robotframework = ">=4.0"
+pyserial = ">=3.0"


### PR DESCRIPTION
install_requires is used with setuptools, with poetry it needs to use poetry.dependencies

Fixes
poetry.core.constraints.version.exceptions.ParseConstraintError: Could not parse version constraint: robotframework